### PR TITLE
Add Stream.group

### DIFF
--- a/streaming/Stream.ml
+++ b/streaming/Stream.ml
@@ -396,19 +396,22 @@ let split ~by:pred self =
     in
   { stream }
 
-
-
-let group ?equal:(_ =Pervasives.(=)) self =
+let group ~break self =
   let stream (Sink k) =
-    let push r x =
-      k.push r x
+    let init () = (k.init (), None, empty) in
+    let push (r, maybe_previous, acc) x =
+      match maybe_previous with
+      | None -> (r, Some x, acc ++ single x)
+      | Some previous ->
+        if break previous x then
+          (k.push r acc, Some x, single x)
+        else (r, Some x, acc ++ single x)
     in
-    self.stream (Sink { k with push })
+    let stop (r, _, acc) = k.stop (k.push r acc) in
+    let full (r, _, _) = k.full r in
+    self.stream (Sink { init; push; full; stop })
     in
   { stream }
-
-
-
 
 (* IO *)
 

--- a/streaming/Streaming.mli
+++ b/streaming/Streaming.mli
@@ -1120,9 +1120,9 @@ module Stream : sig
   val partition : int -> 'a t -> 'a t t
   (** [partition n] partitions the stream into sub-streams of size [n]. *)
 
-  (* TODO *)
-  (* val group : by *)
-
+  val group : break:('a -> 'a -> bool) -> 'a t -> 'a t t
+  (** [group ~break stream] splits [stream] each time two consecutive
+     elements [x] and [y] verify [break x y]. *)
 
   (* TODO: Add variants for splitting once. Consider renaming: divide. *)
   (* split, partition, divide, etc is too confusing. *)

--- a/tests/Stream_tests.ml
+++ b/tests/Stream_tests.ml
@@ -315,6 +315,16 @@ let () =
       ~actual:S.(to_list (map to_list (partition 0 (0-<5))));
   ];
 
+  let t = T.test T.(list (list int)) ~verbose in
+  T.group "Stream.group" [
+    t "empty" ~expected:[[]]
+      ~actual:S.(to_list (map to_list (group ~break:( <> ) empty)));
+    t "of_list" ~expected:[[1;1];[2];[3;3]]
+      ~actual:S.(to_list (map to_list (group ~break:( <> ) (of_list [1;1;2;3;3]))));
+    t "repeat,concat" ~expected:[[1;1];[2;2;2]]
+      ~actual:S.(to_list (map to_list (group ~break:( <> ) (concat (repeat ~times:2 1) (repeat ~times:3 2)) )));
+  ];
+
   let t = T.test T.(list int) ~verbose in
   T.group "Stream.interpose" [
     t "empty" ~expected:[]

--- a/tests/Stream_tests.ml
+++ b/tests/Stream_tests.ml
@@ -321,6 +321,8 @@ let () =
       ~actual:S.(to_list (map to_list (group ~break:( <> ) empty)));
     t "of_list" ~expected:[[1;1];[2];[3;3]]
       ~actual:S.(to_list (map to_list (group ~break:( <> ) (of_list [1;1;2;3;3]))));
+    t "of_list, mod" ~expected:[[1;3];[2];[1;3]]
+      ~actual:S.(to_list (map to_list (group ~break:(fun x y -> x mod 2 <> y mod 2) (of_list [1;3;2;1;3]))));
     t "repeat,concat" ~expected:[[1;1];[2;2;2]]
       ~actual:S.(to_list (map to_list (group ~break:( <> ) (concat (repeat ~times:2 1) (repeat ~times:3 2)) )));
   ];


### PR DESCRIPTION
Here is a tentative implementation of `Stream.group`, similar to [Core.List.group](https://ocaml.janestreet.com/ocaml-core/latest/doc/core_kernel/Core_kernel/List/index.html#val-group).

This PR has two commits, each with a different implementation. The first is very close to `Stream.split`, but since I noticed the comment above asking how efficient this implementation would be, I tried an alternative where the elements of each group are accumulated in a list. I believe it should behave the same but I'd be glad to have a confirmation. Meanwhile, I made a quick check to verify that performance-wise the second version is approximately twice as fast.

The PR certainly needs more work, please let me know what I can do.

